### PR TITLE
Use new request parser, support inline protocol. Fixes #3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "react/promise": "~1",
         "react/socket-client": "0.3.*",
         "react/event-loop": "0.3.*",
-        "clue/redis-protocol": "dev-api"
+        "clue/redis-protocol": "0.3.*"
     },
     "autoload": {
         "psr-0": { "Clue\\Redis\\Server": "src" }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "react/promise": "~1",
         "react/socket-client": "0.3.*",
         "react/event-loop": "0.3.*",
-        "clue/redis-protocol": "0.2.*"
+        "clue/redis-protocol": "dev-api"
     },
     "autoload": {
         "psr-0": { "Clue\\Redis\\Server": "src" }

--- a/composer.lock
+++ b/composer.lock
@@ -3,20 +3,20 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "c65c6fcf70f9cf98b25ecd3c2a0f76a7",
+    "hash": "837a39e7a0b5e8f301c26d3754d1fb4b",
     "packages": [
         {
             "name": "clue/redis-protocol",
-            "version": "dev-api",
+            "version": "v0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/clue/redis-protocol.git",
-                "reference": "1b5ce39a96014123f560415651af19d5f801dcdf"
+                "reference": "2ffcdfa281b1084f666340e13f05a1d26d35ed26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/clue/redis-protocol/zipball/1b5ce39a96014123f560415651af19d5f801dcdf",
-                "reference": "1b5ce39a96014123f560415651af19d5f801dcdf",
+                "url": "https://api.github.com/repos/clue/redis-protocol/zipball/2ffcdfa281b1084f666340e13f05a1d26d35ed26",
+                "reference": "2ffcdfa281b1084f666340e13f05a1d26d35ed26",
                 "shasum": ""
             },
             "require": {
@@ -47,7 +47,7 @@
                 "serializer",
                 "streaming"
             ],
-            "time": "2014-01-26 15:31:00"
+            "time": "2014-01-26 23:49:05"
         },
         {
             "name": "evenement/evenement",
@@ -395,9 +395,9 @@
 
     ],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "clue/redis-protocol": 20
-    },
+    "stability-flags": [
+
+    ],
     "platform": [
 
     ],

--- a/composer.lock
+++ b/composer.lock
@@ -3,20 +3,20 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "b668b00e7d6a37b7409f27d6cd8d1cd1",
+    "hash": "c65c6fcf70f9cf98b25ecd3c2a0f76a7",
     "packages": [
         {
             "name": "clue/redis-protocol",
-            "version": "v0.2.0",
+            "version": "dev-api",
             "source": {
                 "type": "git",
                 "url": "https://github.com/clue/redis-protocol.git",
-                "reference": "eff088be0ee96f877866f975bcf3356ae6f03625"
+                "reference": "1b5ce39a96014123f560415651af19d5f801dcdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/clue/redis-protocol/zipball/eff088be0ee96f877866f975bcf3356ae6f03625",
-                "reference": "eff088be0ee96f877866f975bcf3356ae6f03625",
+                "url": "https://api.github.com/repos/clue/redis-protocol/zipball/1b5ce39a96014123f560415651af19d5f801dcdf",
+                "reference": "1b5ce39a96014123f560415651af19d5f801dcdf",
                 "shasum": ""
             },
             "require": {
@@ -47,7 +47,7 @@
                 "serializer",
                 "streaming"
             ],
-            "time": "2014-01-21 21:28:04"
+            "time": "2014-01-26 15:31:00"
         },
         {
             "name": "evenement/evenement",
@@ -395,9 +395,9 @@
 
     ],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": {
+        "clue/redis-protocol": 20
+    },
     "platform": [
 
     ],

--- a/src/Clue/Redis/Server/Client.php
+++ b/src/Clue/Redis/Server/Client.php
@@ -29,9 +29,9 @@ class Client
         $this->connection->end();
     }
 
-    public function write(ModelInterface $response)
+    public function write($data)
     {
-        $this->connection->write($response->getMessageSerialized());
+        $this->connection->write($data);
     }
 
     public function getRequestDebug(ModelInterface $request)

--- a/src/Clue/Redis/Server/Invoker.php
+++ b/src/Clue/Redis/Server/Invoker.php
@@ -34,25 +34,25 @@ class Invoker
     public function invoke($command, array $args)
     {
         if (!isset($this->commands[$command])) {
-            return new ErrorReply('ERR Unknown or disabled command \'' . $command . '\'');
+            return $this->serializer->getErrorMessage('ERR Unknown or disabled command \'' . $command . '\'');
         }
 
         $n = count($args);
         if ($n < $this->commands[$command]) {
-            return new ErrorReply('ERR wrong number of arguments for \'' . $command . '\' command');
+            return $this->serializer->getErrorMessage('ERR wrong number of arguments for \'' . $command . '\' command');
         }
 
         try {
             $ret = call_user_func_array(array($this->business, $command), $args);
         }
         catch (Exception $e) {
-            return $this->serializer->createReplyModel($e);
+            return $this->serializer->getErrorMessage($e);
         }
 
-        if (!($ret instanceof ModelInterface)) {
-            $ret = $this->serializer->createReplyModel($ret);
+        if ($ret instanceof ModelInterface) {
+            return $ret->getMessageSerialized($this->serializer);
         }
 
-        return $ret;
+        return $this->serializer->getReplyMessage($ret);
     }
 }

--- a/src/Clue/Redis/Server/Invoker.php
+++ b/src/Clue/Redis/Server/Invoker.php
@@ -33,6 +33,8 @@ class Invoker
 
     public function invoke($command, array $args)
     {
+        $command = strtolower($command);
+
         if (!isset($this->commands[$command])) {
             return $this->serializer->getErrorMessage('ERR Unknown or disabled command \'' . $command . '\'');
         }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -13,6 +13,10 @@ class FactoryTest extends TestCase
 
     public function testPairAuthRejectDisconnects()
     {
+        if (defined('HPHP_VERSION')) {
+            $this->markTestSkipped();
+        }
+
         $server = null;
 
         // bind to a random port on the local interface


### PR DESCRIPTION
This now supports running the full redis-benchmark. Fixes #3.
This also significantly improves parsing performance by ~50%.

Depends on clue/redis-protocol#6 to be merged and tagged.
