### PR TITLE
Benchmarks on a AWS c4.xlarge instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,57 @@ performance:
   the host machine instead shows significant improvements (8x). For comparision,
   the same applies to official redis, although it shows a smaller impact (3x).
 
+#### Benchmarking performance on AWS
+
+Some facts about the machine:
+
+* Instance Type: [c4.xlarge](https://aws.amazon.com/ec2/instance-types/?nc1=h_ls#compute-optimized) (16 ECUs, 4 vCPUs, 2.9 GHz, Intel Xeon E5-2666v3, 7.5 GiB memory, EBS only, compute optimized)
+* Availability Zone: eu-central-1b (Frankfurt, Germany)
+* AMI: Ubuntu Server 14.04 LTS (HVM), SSD Volume Type - ami-87564feb
+
+Some benchmarking results:
+
+```
+# Official redis-server
+# 	redis_version:2.8.4
+# 	redis_build_id:a44a05d76f06a5d9
+# 	redis_mode:standalone
+# 	os:Linux 3.13.0-74-generic x86_64
+# 	arch_bits:64
+# 	gcc_version:4.8.2
+# 	mem_allocator:jemalloc-3.4.1
+$ redis-server
+$ redis-benchmark -t set,get -q
+SET: 181818.19 requests per second
+GET: 185185.19 requests per second
+
+# clue/redis-server
+#	PHP 7.0.2-4+deb.sury.org~trusty+1 (cli) ( NTS )
+#	Copyright (c) 1997-2015 The PHP Group
+#	Zend Engine v3.0.0, Copyright (c) 1998-2015 Zend Technologies
+#	    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2015, by Zend Technologies
+$ php bin/redis-server.php
+$ redis-benchmark -t set,get -q
+SET: 78125.00 requests per second
+GET: 75187.97 requests per second
+
+# clue/redis-server
+# 	HipHop VM 3.11.0 (rel)
+#	Compiler: tags/HHVM-3.11.0-0-g3dd564a8cde23e3205a29720d3435c771274085e
+#	Repo schema: 52047bdda550f21c2ec2fcc295e0e6d02407be51
+$ hhvm -vEval.Jit=true bin/redis-server.php
+$ redis-benchmark -t set,get -q
+SET: 70921.98 requests per second
+GET: 71942.45 requests per second
+```
+
+Some notes about the benchmark:
+
+* Date of benchmark: 2016-01-22, ~9pm
+* The instance was running on a shared instance. There might be more performance on a [dedicated instance](https://aws.amazon.com/ec2/purchasing-options/dedicated-instances/) or even on a [dedicated host](https://aws.amazon.com/ec2/dedicated-hosts/).
+* PHP7 was not self-compiled. The precompiled version by [Ondřej Surý](https://github.com/oerdnj) was used. There might be more performance available by a custom compiled PHP version.
+* The PHP-Extension [libevent](https://pecl.php.net/package/libevent) was not available for PHP 7 at the time of the benchmark.
+
 ## Quickstart example
 
 Once [installed](#install), you can run any of the examples provided:

--- a/README.md
+++ b/README.md
@@ -96,11 +96,10 @@ supported by redis. If you find a command is missing, please submit a PR :)
 
 > As usual, just about *every* benchmark is biased - you've been warned.
 
-You can use the `redis-benchmark` script that is included when installing the
-official redis server.
+We used the [official benchmark tool](http://redis.io/topics/benchmarks) `redis-benchmark` script that is included when installing the official redis server.
 
 ```bash
-$ redis-benchmark -p 1337 -q
+$ redis-benchmark -t set,get -q
 ```
 
 Some benchmarking results:


### PR DESCRIPTION
### Motivation

As discussed at the [Januar edition of the PHP Usergroup Düsseldorf](http://www.meetup.com/de-DE/PHP-Usergroup-Duesseldorf/events/227265708/) with this pull request i add a new benchmark for this **awesome** project!

My first attempt was on [DigitalOcean](https://www.digitalocean.com/). I booted the biggest machine there (in the hope that i got a bigger CPU compared to the smallest one), but this was not successful.
The native redis benchmarks were lower then the ones you already provided in the README (55000.0 requests per second for SET commands).
I tried this 5 times with new machines to minimize the noisy [neighbor problem](https://en.wikipedia.org/wiki/Cloud_computing_issues#Performance_interference_and_noisy_neighbors).
This is the reason why there will no DigitalOcean benchmark.
### Benchmark

My second attempt was on AWS.
I chose a `c4.xlarge` (optimized for computing), because IMO a benchmark for ops/sec in Redis is (mainly) CPU bound. I booted the instance as a shared instance in Frankfurt, Germany.
I created the same benchmarks as you did with:
- Native Redis Server
- PHP7
- HHVM

I was quite impressed that the "new" benchmarks are quite high compared to the existing ones.
Checkout the PR content for concrete numbers.
Sadly i was not able to run the PHP7 benchmark with `ext-libevent`, because this extension is not available for PHP7 (yet). Even the fork [expressif/pecl-event-libevent](https://github.com/expressif/pecl-event-libevent) is not complete and able to run (in my experiment).
During composer installation the extension `ext-ev` ([PECL](https://pecl.php.net/package/ev)) was suggested. I installed it, but the benchmarks didn't changed. I didn't had a deeper look in the usage of `ext-ev` in react.

Every run (Native, PHP7, HHVM) was executed 7 or 8 times and the highest value was chosen.
I tried to add as much (important) information into the benchmark chapter as possible.
Here are a few more:
### Benchmark environment details

PHP Installation:

```
ubuntu@ip-172-31-25-230:~/php-redis-server$ php -v
PHP 7.0.2-4+deb.sury.org~trusty+1 (cli) ( NTS )
Copyright (c) 1997-2015 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2015 Zend Technologies
    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2015, by Zend Technologies

ubuntu@ip-172-31-25-230:~/php-redis-server$ php -m
[PHP Modules]
bcmath
calendar
Core
ctype
date
dba
dom
exif
fileinfo
filter
ftp
gettext
hash
iconv
json
libxml
mbstring
mysqlnd
openssl
pcntl
pcre
PDO
Phar
posix
readline
Reflection
session
SimpleXML
soap
sockets
SPL
standard
sysvmsg
sysvsem
sysvshm
tokenizer
xml
xmlreader
xmlwriter
Zend OPcache
zip
zlib

[Zend Modules]
Zend OPcache
```

HHVM installation

```
ubuntu@ip-172-31-25-230:~$ hhvm --version
HipHop VM 3.11.0 (rel)
Compiler: tags/HHVM-3.11.0-0-g3dd564a8cde23e3205a29720d3435c771274085e
Repo schema: 52047bdda550f21c2ec2fcc295e0e6d02407be51
```
- `cat /proc/cpuinfo`: https://gist.github.com/andygrunwald/04dad2bfc45056009b98
- `/proc/meminfo`: https://gist.github.com/andygrunwald/2bfdc75233e08260e0dc
### Installation guide to reproduce

```
$ sudo apt-get install -y language-pack-en-base \
   && LC_ALL=en_US.UTF-8 sudo add-apt-repository -y ppa:ondrej/php \
   && sudo apt-get update \
   && sudo apt-get install -y git-core redis-server php7.0 \
   && sudo /etc/init.d/apache2 stop

$ redis-benchmark -t set,get -q

$ sudo /etc/init.d/redis-server stop

$ git clone https://github.com/clue/php-redis-server.git \
   && cd php-redis-server \
   && curl -sS https://getcomposer.org/installer | php \
   && php composer.phar install -o

$ php bin/redis-server.php

$ redis-benchmark -t set,get -q

$ sudo apt-get install -y software-properties-common \
   && sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449 \
   && sudo add-apt-repository -y "deb http://dl.hhvm.com/ubuntu $(lsb_release -sc) main" \
   && sudo apt-get -y update \
   && sudo apt-get -y install hhvm

$ LC_CTYPE="en_US.UTF-8"
$ LC_ALL="en_US.UTF-8"
$ hhvm -vEval.Jit=true bin/redis-server.php

$ redis-benchmark -t set,get -q
```
### Side notes

I kept the original benchmarks for a reference.
If you have questions or need more information to reproduce, let me know.
